### PR TITLE
Tag commercial-steward link with UTM source for traffic attribution

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -137,7 +137,7 @@ export const stewardship = {
   title: 'CoDimensional PBC is PyVista’s commercial steward.',
   statement: 'Founded by PyVista maintainers, building collaborative 3D on top of the project.',
   cta: {
-    href: 'https://codimensional.com',
+    href: 'https://codimensional.com/?utm_source=pyvista&utm_medium=referral&utm_campaign=homepage-banner',
     label: 'Learn more',
   },
 };


### PR DESCRIPTION
The homepage commercial-steward banner links to `codimensional.com` with no query params, so CoDim's analytics can't separate clicks that originate here from any other source.

This adds UTM params to the banner link:

```
https://codimensional.com/?utm_source=pyvista&utm_medium=referral&utm_campaign=homepage-banner
```

No visual or behavioral change. The link is same-tab and carries no `rel=noreferrer`, so the referrer header already flows; the UTM tags add campaign-level granularity and distinguish this placement from the docs-sidebar ad.